### PR TITLE
FISH-379 Fix Masthead Styling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sun.woodstock</groupId>
     <artifactId>webui-jsf-suntheme</artifactId>
-    <version>4.0.2.10.payara-p21</version>
+    <version>4.0.2.10.payara-p22-SNAPSHOT</version>
 
     <properties>
         <encoding>UTF-8</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sun.woodstock</groupId>
     <artifactId>webui-jsf-suntheme</artifactId>
-    <version>4.0.2.10.payara-p21-SNAPSHOT</version>
+    <version>4.0.2.10.payara-p21</version>
 
     <properties>
         <encoding>UTF-8</encoding>

--- a/src/main/resources/com/sun/webui/jsf/suntheme/css/layout.css
+++ b/src/main/resources/com/sun/webui/jsf/suntheme/css/layout.css
@@ -777,6 +777,7 @@ a.MstLnk_sun4:hover,a.MstLnkLft_sun4:hover, a.MstLnkRt_sun4:hover, a.MstLnkCen_s
 .MstTblEnd_sun4 {
     background-repeat:repeat-x;
     background-position:left top;
+    width: auto;
 }
 .MstTblEnd_sun4 tr > td {
     padding:1px 0 2px 0;
@@ -1271,9 +1272,6 @@ select + br + br {
 }
 
 /* Header statuses */
-.MstTblBot_sun4 {
-    width: auto;
-}
 .MstTblBot_sun4 td {
     display: flex;
     flex-flow: row-reverse nowrap;


### PR DESCRIPTION
Restart required would fill the entire row, and the firefox rendering of
width: auto was different for the top table, causing all elements to
shift to the left.