### PR TITLE
Disabled buttons styling

### DIFF
--- a/src/main/resources/com/sun/webui/jsf/suntheme/css/colorAndMedia.css
+++ b/src/main/resources/com/sun/webui/jsf/suntheme/css/colorAndMedia.css
@@ -991,6 +991,14 @@ input[type="submit"]:hover,
 a.TskScnTxtBg_sun4:not([onclick*=".payara."]):hover {
     background: #315462;
 }
+input[type="submit"]:disabled {
+    font-style: italic;
+    color: #ccc;
+    color: rgba(255,255,255,0.5);
+}
+input[type="submit"]:disabled:hover {
+    background: #1A4151;
+}
 
 /* Home page links */
 input[name*="utilityBar"]:hover {


### PR DESCRIPTION
Before this, disabled buttons use the same style as non-disabled ones, so it's not possible to see which are disabled and which are not.

With this change, disabled buttons appear as disabled:

![image](https://user-images.githubusercontent.com/2195988/109956931-87f06b00-7ce4-11eb-89df-342321199096.png)
